### PR TITLE
ci-cd using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+os: linux
+dist: trusty
+sudo: false
+branches:
+  only: master
+before_install:
+  - wget https://github.com/gohugoio/hugo/releases/download/v0.30.2/hugo_0.30.2_Linux-64bit.deb
+  - sudo dpkg -i hugo_0.30.2_Linux-64bit.deb
+  - rm hugo_0.30.2_Linux-64bit.deb
+  - hugo version
+addons:
+  apt:
+    update: true
+script: hugo
+before_deply: touch ./docs/.nojekyll
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: false
+  on:
+    branch: master
+  target-branch: gh-pages
+  local-dir: docs
+verbose: true


### PR DESCRIPTION
Build Hugo project automatically and deploy to GitHub Pages using Travis for the time being.

[Poc](https://jlosito.github.io/practice-library/)
[Logs from Travis](https://travis-ci.org/jlosito/practice-library)

Note that one will need to setup the token within Travis. One can refer to the following links.
https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
