### PR TITLE
Search fixes

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -12,8 +12,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='website'><meta property='og:updated_time' content='2018-06-08T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>404 Page not found • Open Practice Library</title>
   <link rel='canonical' href=''>
@@ -44,7 +43,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -56,11 +55,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -14,8 +14,7 @@ Share the Big Picture Describe how Red Hat and Red Hat Open Innovation Labs use 
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Page'><meta property='article:published_time' content='2017-10-19T17:03:59-04:00'/><meta property='article:modified_time' content='2017-10-19T17:03:59-04:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>About • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/about/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a class='current' aria-current='page' href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -12,7 +12,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='website'><meta property='og:updated_time' content='2018-06-08T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Categories • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/categories/'>
@@ -45,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -57,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -1,9 +1,46 @@
 /* Search Bar Styling */
-#searchInput {
+
+.search-input,
+.search-button {
+	font-size: 1.125rem;
+	line-height: 1;
+}
+
+.search-controls .search-input {
 	display: inline;
-	width: 300px !important;
-	margin-right: 7px; 
-	margin-bottom: 5px !important;
+	width: 250px;
+	margin-bottom: 5px;
+	margin-right: 5px;
+	padding: 8px;
+}
+
+.search-button {
+	cursor: pointer;
+	padding: 9px; /* 1px more of padding because this button doesn't have a border. */
+}
+
+.search-button:hover,
+.search-button:focus {
+	background-color: #ffdc4d;
+	color: #000;
+}
+
+@media (min-width: 768px) {
+	.search-controls {
+		float: right;
+		margin-top: -5px;
+	}
+}
+
+/* Micro clearfix - http://nicolasgallagher.com/micro-clearfix-hack/ */
+.clearfix:before,
+.clearfix:after {
+    content: " ";
+    display: table;
+}
+
+.clearfix:after {
+    clear: both;
 }
 
 .list-item .meta,
@@ -54,4 +91,3 @@
 .related-list a:hover {
     border-bottom-color: #ffcd00;
 }
-

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,8 +12,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='website'><meta property='og:image' content='https://rht-labs.github.io/images/route-sketch.png'><meta property='og:updated_time' content='2018-06-08T00:00:00-05:00'/><meta name='twitter:card' content='summary_large_image'><meta property='twitter:image' content='https://rht-labs.github.io/images/route-sketch.png'><meta property='twitter:image:alt' content='Illustration of people participating in event storming, screen flow, priority sliders, and story slicing'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a class='current' aria-current='page' href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/js/search.js
+++ b/docs/js/search.js
@@ -1,31 +1,31 @@
 (function() {
 	var url = new URL(window.location.href);
 	var searchTerm = url.searchParams.get('search');
-	
+
 	var cleanedResults = "";
-		
-	
+
+
 	var RESULTS = document.getElementById("results-wrapper");
-		
-	
+
+
 	var idx = lunr(function () {
 	  this.ref('href')
 	  this.field('content')
-	
+
 	  data.forEach(function (doc) {
 	    this.add(doc)
 	  }, this)
 	})
-	
+
 	var initialResults = idx.search(searchTerm);
-	
+
 	for (var i = 0; i < initialResults.length; i++) {
 		var res = initialResults[i].ref;
 		res = res.replace(/-/g, " ").replace(/([^a-z]|^)([a-z])(?=[a-z]{2})/g, function(_, g1, g2) { return g1 + g2.toUpperCase();});
-		cleanedResults += "<li class='list-item'><article><header class='list-item-header'><h3 class='list-item-title'><a href='https://" + window.location.origin + "/practice-library/practices/" +  initialResults[i].ref + "'>" + res + "</a></li></article></header></h3></header></article></li>";
+		cleanedResults += "<li class='list-item'><article><header class='list-item-header'><h3 class='list-item-title'><a href='" + window.location.origin + "/practice-library/practices/" +  initialResults[i].ref + "'>" + res + "</a></li></article></header></h3></header></article></li>";
 	}
-	
-	
-		
+
+
+
 	RESULTS.innerHTML = cleanedResults;
 })();

--- a/docs/js/searchButton.js
+++ b/docs/js/searchButton.js
@@ -1,5 +1,5 @@
-var searchfield = document.getElementById('searchInput');
-var searchbutton = document.getElementById('searchButton');
+var searchfield = document.getElementById('search-input');
+var searchbutton = document.getElementById('search-button');
 
 searchfield.addEventListener("keyup", function(event) {
 	event.preventDefault();

--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -12,8 +12,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='website'><meta property='og:updated_time' content='2018-06-08T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Pages • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/page/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/agile-agenda/index.html
+++ b/docs/practices/agile-agenda/index.html
@@ -12,8 +12,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2017-05-15T00:00:00-05:00'/><meta property='article:modified_time' content='2017-05-15T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Agile Agenda • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/agile-agenda/'>
@@ -44,7 +43,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -56,11 +55,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/burndown/index.html
+++ b/docs/practices/burndown/index.html
@@ -14,8 +14,7 @@ Teams often use burndown charts to track progress within fixed time periods (for
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2018-04-07T23:33:55&#43;01:00'/><meta property='article:modified_time' content='2018-04-07T23:33:55&#43;01:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Burndown • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/burndown/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/event-storming/index.html
+++ b/docs/practices/event-storming/index.html
@@ -14,8 +14,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2017-04-20T00:00:00-05:00'/><meta property='article:modified_time' content='2017-04-20T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Event Storming • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/event-storming/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/impact-mapping/index.html
+++ b/docs/practices/impact-mapping/index.html
@@ -14,8 +14,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2017-09-06T00:00:00-05:00'/><meta property='article:modified_time' content='2017-09-06T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Impact Mapping • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/impact-mapping/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/index.html
+++ b/docs/practices/index.html
@@ -12,8 +12,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='website'><meta property='og:updated_time' content='2018-06-08T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Practices • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/page/2/index.html
+++ b/docs/practices/page/2/index.html
@@ -12,8 +12,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='website'><meta property='og:updated_time' content='2018-06-08T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Practices • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/prep-week/index.html
+++ b/docs/practices/prep-week/index.html
@@ -14,8 +14,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2018-02-16T00:00:00-05:00'/><meta property='article:modified_time' content='2018-02-16T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Prep Week • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/prep-week/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/realtime-retrospective/index.html
+++ b/docs/practices/realtime-retrospective/index.html
@@ -14,8 +14,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2017-10-26T00:00:00-05:00'/><meta property='article:modified_time' content='2017-10-26T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Realtime Retrospective • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/realtime-retrospective/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/retrospectives/index.html
+++ b/docs/practices/retrospectives/index.html
@@ -14,8 +14,7 @@ Why use Retrospectives? Retrospectives facilitate continous improvement. Rather 
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2017-11-21T00:00:00-05:00'/><meta property='article:modified_time' content='2017-11-21T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Retrospectives • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/retrospectives/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/social-contract/index.html
+++ b/docs/practices/social-contract/index.html
@@ -16,8 +16,7 @@ To effectively use this practice you should look to create the following outcome
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2017-11-21T00:00:00-05:00'/><meta property='article:modified_time' content='2017-11-21T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Social Contract • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/social-contract/'>
@@ -48,7 +47,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -60,11 +59,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/start-at-the-end/index.html
+++ b/docs/practices/start-at-the-end/index.html
@@ -12,8 +12,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2018-06-08T00:00:00-05:00'/><meta property='article:modified_time' content='2018-06-08T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Start At The End • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/start-at-the-end/'>
@@ -44,7 +43,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -56,11 +55,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/stop-the-world-event/index.html
+++ b/docs/practices/stop-the-world-event/index.html
@@ -14,8 +14,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2017-10-26T16:20:14-04:00'/><meta property='article:modified_time' content='2017-10-26T16:20:14-04:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Stop the World Event • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/stop-the-world-event/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/team-sentiment/index.html
+++ b/docs/practices/team-sentiment/index.html
@@ -14,8 +14,7 @@ Why use a Team Sentiment pratice? Team sentiment practices enable problems to be
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2018-03-31T22:53:43&#43;01:00'/><meta property='article:modified_time' content='2018-03-31T22:53:43&#43;01:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Team Sentiment • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/team-sentiment/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/user-story-mapping/index.html
+++ b/docs/practices/user-story-mapping/index.html
@@ -1,7 +1,4 @@
-<!DOCTYPE html><<<<<<< PullRequest
-18
- 
-
+<!DOCTYPE html>
 <html lang='en'>
 
 <head>
@@ -17,7 +14,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2017-04-20T00:00:00-05:00'/><meta property='article:modified_time' content='2017-04-20T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
+<meta name="generator" content="Hugo 0.43" />
 
   <title>User Story Mapping • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/user-story-mapping/'>
@@ -48,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -60,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/visualisation-of-work/index.html
+++ b/docs/practices/visualisation-of-work/index.html
@@ -14,8 +14,7 @@ The &ldquo;Information Radiator&rdquo; is an artefact that is used to physically
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2018-04-08T21:41:51&#43;01:00'/><meta property='article:modified_time' content='2018-04-08T21:41:51&#43;01:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Visualisation of Work • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/visualisation-of-work/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/practices/vsm-and-mbpm/index.html
+++ b/docs/practices/vsm-and-mbpm/index.html
@@ -12,8 +12,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Practices'><meta property='article:published_time' content='2017-09-12T00:00:00-05:00'/><meta property='article:modified_time' content='2017-09-12T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Value Stream Mapping (VSM) and Metrics-Based Process Mapping (MBPM) • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/practices/vsm-and-mbpm/'>
@@ -44,7 +43,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -56,11 +55,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -14,7 +14,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='article'><meta property='article:section' content='Page'><meta property='article:published_time' content='2017-10-19T17:03:59-04:00'/><meta property='article:modified_time' content='2017-10-19T17:03:59-04:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Search • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/search/'>
@@ -45,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -57,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -12,8 +12,7 @@
 <meta property='og:site_name' content='Open Practice Library'>
 <meta property='og:type' content='website'><meta property='og:updated_time' content='2018-06-08T00:00:00-05:00'/><meta name='twitter:card' content='summary'>
 
-<meta name="generator" content="Hugo 0.42.2" />
-
+<meta name="generator" content="Hugo 0.43" />
 
   <title>Tags • Open Practice Library</title>
   <link rel='canonical' href='https://rht-labs.github.io/practice-library/tags/'>
@@ -46,7 +45,7 @@ if (!doNotTrack) {
     <header id='header' class='header-container'>
       <div class='header site-header'>
         
-<nav id='main-menu' class='main-menu-container' aria-label='Main Menu'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='Main Menu'>
   <ul class='main-menu'>
   <li>
       <a href='https://rht-labs.github.io/practice-library/'>Home</a>
@@ -58,11 +57,9 @@ if (!doNotTrack) {
       <a href='https://rht-labs.github.io/practice-library/about/'>About</a>
     </li>
   
-    <li>
-      <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/layouts/partials/nav/menus/main.html
+++ b/layouts/partials/nav/menus/main.html
@@ -9,9 +9,9 @@
       </a>
     </li>
   {{ end }}
-    <li class="main-menu-search">
-      <input type="text" id="searchInput" placeholder="Search">
-      <button id="searchButton">Search</button>
+    <li class="search-controls">
+      <input type="text" id="search-input" class="search-input" placeholder="Search">
+      <button id="search-button" class="search-button">Search</button>
     </li>
   </ul>
 </nav>

--- a/layouts/partials/nav/menus/main.html
+++ b/layouts/partials/nav/menus/main.html
@@ -1,5 +1,5 @@
 
-<nav id='main-menu' class='main-menu-container' aria-label='{{ i18n "mainMenu" }}'>
+<nav id='main-menu' class='main-menu-container clearfix' aria-label='{{ i18n "mainMenu" }}'>
   <ul class='main-menu'>
   {{ range .Site.Menus.main }}
     {{- $isCurrent := ( or ( $.IsMenuCurrent "main" . ) ( $.HasMenuCurrent "main" . ) ) -}}
@@ -9,10 +9,8 @@
       </a>
     </li>
   {{ end }}
-    <li>
+    <li class="main-menu-search">
       <input type="text" id="searchInput" placeholder="Search">
-    </li>
-    <li>
       <button id="searchButton">Search</button>
     </li>
   </ul>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,37 +1,36 @@
 /* Search Bar Styling */
 
-#searchInput,
-#searchButton {
+.search-input,
+.search-button {
 	font-size: 1.125rem;
 	line-height: 1;
 }
 
-#searchInput {
+.search-controls .search-input {
 	display: inline;
-	width: 250px !important;
-	margin-bottom: 5px !important;
+	width: 250px;
+	margin-bottom: 5px;
 	margin-right: 5px;
 	padding: 8px;
 }
 
-@media (min-width: 768px) {
-	.main-menu-search {
-		float: right;
-		margin-top: -5px;
-	}
-}
-
-#searchButton {
+.search-button {
 	cursor: pointer;
 	padding: 9px; /* 1px more of padding because this button doesn't have a border. */
 }
 
-#searchButton:hover,
-#searchButton:focus {
+.search-button:hover,
+.search-button:focus {
 	background-color: #ffdc4d;
 	color: #000;
 }
 
+@media (min-width: 768px) {
+	.search-controls {
+		float: right;
+		margin-top: -5px;
+	}
+}
 
 /* Micro clearfix - http://nicolasgallagher.com/micro-clearfix-hack/ */
 .clearfix:before,

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,9 +1,47 @@
 /* Search Bar Styling */
+
+#searchInput,
+#searchButton {
+	font-size: 1.125rem;
+	line-height: 1;
+}
+
 #searchInput {
 	display: inline;
-	width: 300px !important;
-	margin-right: 7px; 
+	width: 250px !important;
 	margin-bottom: 5px !important;
+	margin-right: 5px;
+	padding: 8px;
+}
+
+@media (min-width: 768px) {
+	.main-menu-search {
+		float: right;
+		margin-top: -5px;
+	}
+}
+
+#searchButton {
+	cursor: pointer;
+	padding: 9px; /* 1px more of padding because this button doesn't have a border. */
+}
+
+#searchButton:hover,
+#searchButton:focus {
+	background-color: #ffdc4d;
+	color: #000;
+}
+
+
+/* Micro clearfix - http://nicolasgallagher.com/micro-clearfix-hack/ */
+.clearfix:before,
+.clearfix:after {
+    content: " ";
+    display: table;
+}
+
+.clearfix:after {
+    clear: both;
 }
 
 .list-item .meta,
@@ -54,4 +92,3 @@
 .related-list a:hover {
     border-bottom-color: #ffcd00;
 }
-

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,31 +1,31 @@
 (function() {
 	var url = new URL(window.location.href);
 	var searchTerm = url.searchParams.get('search');
-	
+
 	var cleanedResults = "";
-		
-	
+
+
 	var RESULTS = document.getElementById("results-wrapper");
-		
-	
+
+
 	var idx = lunr(function () {
 	  this.ref('href')
 	  this.field('content')
-	
+
 	  data.forEach(function (doc) {
 	    this.add(doc)
 	  }, this)
 	})
-	
+
 	var initialResults = idx.search(searchTerm);
-	
+
 	for (var i = 0; i < initialResults.length; i++) {
 		var res = initialResults[i].ref;
 		res = res.replace(/-/g, " ").replace(/([^a-z]|^)([a-z])(?=[a-z]{2})/g, function(_, g1, g2) { return g1 + g2.toUpperCase();});
-		cleanedResults += "<li class='list-item'><article><header class='list-item-header'><h3 class='list-item-title'><a href='https://" + window.location.origin + "/practice-library/practices/" +  initialResults[i].ref + "'>" + res + "</a></li></article></header></h3></header></article></li>";
+		cleanedResults += "<li class='list-item'><article><header class='list-item-header'><h3 class='list-item-title'><a href='" + window.location.origin + "/practice-library/practices/" +  initialResults[i].ref + "'>" + res + "</a></li></article></header></h3></header></article></li>";
 	}
-	
-	
-		
+
+
+
 	RESULTS.innerHTML = cleanedResults;
 })();

--- a/static/js/searchButton.js
+++ b/static/js/searchButton.js
@@ -1,5 +1,5 @@
-var searchfield = document.getElementById('searchInput');
-var searchbutton = document.getElementById('searchButton');
+var searchfield = document.getElementById('search-input');
+var searchbutton = document.getElementById('search-button');
 
 searchfield.addEventListener("keyup", function(event) {
 	event.preventDefault();


### PR DESCRIPTION
@rohitmusti, do the changes below look okay to you? If so, I'll merge this branch into the `search` branch and then merge that into `master`. If you have any questions, just let me know! :smile: 

---

- Fix bug that prevented search result links from working
- Make the search box and button a bit subtler (smaller, lighter hover state, right aligned)
- Prevent search from wrapping to a second line on the "practices" page
- Prevent search button and search field from getting separated at some screen sizes
- Code style changes
  - Don't use `!important`
  - Use kebab-case for classes and IDs.
  - Use classes for styling and IDs for JS hooks. 
  - See [Specifics on specificity](https://css-tricks.com/specifics-on-css-specificity/) for more info.

## Before
![before](https://user-images.githubusercontent.com/1299370/42478351-60b4b9da-83a2-11e8-9d20-6ac216840d29.png)

## After
![after](https://user-images.githubusercontent.com/1299370/42478356-642cda66-83a2-11e8-9f42-2c3754ed8f30.png)


This PR includes a Hugo rebuild. For just the code changes, see [this comparison](https://github.com/rht-labs/practice-library/compare/search...search-fixes%5E).